### PR TITLE
Force deploy

### DIFF
--- a/bot_the_builder.py
+++ b/bot_the_builder.py
@@ -119,7 +119,7 @@ class Builder(object):
                     print(f'Detected change in dependency [{dep}]')
                     return True
 
-    def all(self, path=".", dry=False):
+    def all(self, path=".", dry=False, force=False):
         # TODO: Check that path is in a git repo
 
         if dry:
@@ -134,7 +134,7 @@ class Builder(object):
             if 'Dockerfile' in filenames and 'Makefile' in filenames:
                 print(f'Found a deployable app at [{dirpath}]')
 
-                if self.has_changed(dirpath, changed_files):
+                if self.has_changed(dirpath, changed_files) or force:
                     print(f'App in [{dirpath}] was modified since last master deploy')
 
                     do_cloudbuild = 'cloudbuild.yml' in filenames or 'cloudbuild.yml.template' in filenames


### PR DESCRIPTION
Added a way to force a deploy even if no files were changed since last master commit. 

I need that feature for the clear app, because the api and the client stand in the same repository. Let me explain:
If you remember, I had problems building and deploying the solution when the dockerfile and the makefile were at the root of the repo. That's when I nested all that was related to the api in a subfolder, along with its makefile and dockerfile. As the builder checks for modifications in the current folder and its subfolders, it doesn't detect that the client could have been modified. In this repo, a merge in master most definitely needs to be deployed, as both the api and the client are bundled in the same docker image. The longterm solution would definitely be to have a different build process for the api and the client, each with its own docker/make file, and be deployed separately, and it would fit well with the monorepo theory and bot the builder. For now though, this would solve my problem.

I know it might look like a shady workaround, so if you have suggestions, I'm listening.